### PR TITLE
Enable AMX on linux instances by updating to Ubuntu 22.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Example of main.tf
 module "linux_vm" {
   source              = "intel/gcp-vm/intel"
   project             = var.project
-  boot_image_family   = "ubuntu-2004-lts"
+  boot_image_family   = "ubuntu-2204-lts"
   name                = "this-is-a-linux-vm"
   access_config = [{
     nat_ip                 = null

--- a/examples/gcp-linux-vm-spot/README.md
+++ b/examples/gcp-linux-vm-spot/README.md
@@ -30,7 +30,7 @@ main.tf
 module "spot_vm" {
   source                    = "intel/gcp-vm/intel"
   project                   = var.project
-  boot_image_family         = "ubuntu-2004-lts"
+  boot_image_family         = "ubuntu-2204-lts"
   name                      = "this-is-a-spot-vm"
   on_host_maintenance       = "TERMINATE"
   preemptible               = true

--- a/examples/gcp-linux-vm-spot/main.tf
+++ b/examples/gcp-linux-vm-spot/main.tf
@@ -3,7 +3,7 @@
 module "spot_vm" {
   source                    = "intel/gcp-vm/intel"
   project                   = var.project
-  boot_image_family         = "ubuntu-2004-lts"
+  boot_image_family         = "ubuntu-2204-lts"
   name                      = "this-is-a-spot-vm"
   on_host_maintenance       = "TERMINATE"
   preemptible               = true

--- a/examples/gcp-linux-vm/README.md
+++ b/examples/gcp-linux-vm/README.md
@@ -30,7 +30,7 @@ main.tf
 module "linux_vm" {
   source              = "intel/gcp-vm/intel"
   project             = var.project
-  boot_image_family   = "ubuntu-2004-lts"
+  boot_image_family   = "ubuntu-2204-lts"
   name                = "this-is-a-linux-vm"
   access_config = [{
     nat_ip                 = null

--- a/examples/gcp-linux-vm/main.tf
+++ b/examples/gcp-linux-vm/main.tf
@@ -3,7 +3,7 @@
 module "linux_vm" {
   source              = "intel/gcp-vm/intel"
   project             = var.project
-  boot_image_family   = "ubuntu-2004-lts"
+  boot_image_family   = "ubuntu-2204-lts"
   name                = "this-is-a-Saphire-Rapids-vm-Booyahv4"
   access_config = [{
     nat_ip                 = null


### PR DESCRIPTION
Google recommends updating to Ubuntu 22.04 to use AMX with C3 nodes. See [here](https://cloud.google.com/compute/docs/cpu-platforms
 ). Changed examples and docs to default to 22.04